### PR TITLE
Improved progress bar when processing.

### DIFF
--- a/source/gui/ProcessTab/ProcessWidget.h
+++ b/source/gui/ProcessTab/ProcessWidget.h
@@ -82,6 +82,10 @@ public slots:
      * All selected Pipelines will be automatically added to the default Pipelines and the Pipeline menu.
      */
     void addPipelinesFromDisk();
+    /**
+     * @brief Update progress dialog
+     */
+    void updateProgress();
 private:
     QVBoxLayout* _main_layout; /* Principal layout holder for the current custom QWidget */
     QStackedLayout* _stacked_layout;


### PR DESCRIPTION
Related to issues #35 and #36
Done by getting progress directly from all patch generators in pipeline. 
Requires new version of FAST.