### PR TITLE
Added bug_report and feature_request issue templates

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATES/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATES/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: 'Please do not use issues for questions. Use discussions Q&A https://github.com/AICAN-Research/FAST-Pathology/discussions/new?category=q-a instead.'
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is. 
+**Please do not use issues for questions. Use discussions Q&A https://github.com/AICAN-Research/FAST-Pathology/discussions/new?category=q-a instead and we will do our best to help you!**
+
+**To Reproduce**
+Steps and data to reproduce the behavior, e.g.: 
+"Run pipeline X with image Y stored in format Z."
+
+**System:**
+- OS and version: [e.g. Windows 10/Ubuntu 18.04]
+- GPU and OpenCL vendor (NVIDIA, AMD, Intel)
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.

--- a/.github/workflows/ISSUE_TEMPLATES/feature_request.md
+++ b/.github/workflows/ISSUE_TEMPLATES/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: 'Suggest a new feature for FAST. Please do not use issues for questions. Use discussions Q&A https://github.com/AICAN-Research/FAST-Pathology/discussions/new?category=q-a instead.'
+title: ''
+labels: new feature
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Do you have an idea of how it can/should be implemented?**
+If applicable, how do you think this feature can be implemented in FastPathology.
+Ex. bullet point list of things that need to be done.
+
+**Are you willing to contribute to the implementation of this feature**
+If yes, which parts can you implement, and which parts do you need help from others.


### PR DESCRIPTION
It is probably useful for users and contributors to have issue templates.

It can also be used to promote the `Discussions` tab, which I believe clinicians would find more natural.

Templates were derived from the FAST project.

[no ci]