### PR TITLE
Added support for selecting images with "*.otif" extension

### DIFF
--- a/source/gui/ProjectTab/ProjectWidget.cpp
+++ b/source/gui/ProjectTab/ProjectWidget.cpp
@@ -109,7 +109,7 @@ namespace fast {
     void ProjectWidget::selectFile() {
         // TODO: Unable to read .zvi and .scn (Zeiss and Leica). I'm wondering if they are stored in some unexpected way (not image pyramids)
         auto fileNames = QFileDialog::getOpenFileNames(this, tr("Select File(s)"), nullptr,
-                                                       tr("WSI Files (*.tiff *.tif *.svs *.ndpi *.bif *.vms *.vsi *.mrxs);;All Files(*)"), //*.zvi *.scn)"),
+                                                       tr("WSI Files (*.tiff *.tif *.svs *.ndpi *.bif *.vms *.vsi *.mrxs *.otif);;All Files(*)"), //*.zvi *.scn)"),
                 nullptr, QFileDialog::DontUseNativeDialog);
 
         auto progDialog = QProgressDialog(this);


### PR DESCRIPTION
As discussed https://github.com/AICAN-Research/FAST-Pathology/issues/93#issuecomment-1884780982, FastPathology seems to support WSIs from the Optac format which are stored with `*.otif` extension.

There seems to be some WSIs that have challenges, but in general, it seems to work fine, so we should make it possible for users to select these images through the File selector.